### PR TITLE
#188 質問リストの質問タイトルの表示文字数制限 60文字

### DIFF
--- a/qa-custom-qlist-layer.php
+++ b/qa-custom-qlist-layer.php
@@ -1,0 +1,21 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+	const TITLE_MAX_LENGTH = 60;
+
+	public function q_list_and_form($q_list)
+	{
+		if (isset($q_list['qs'])) {
+			foreach ($q_list['qs'] as $index => $field) {
+				$len = mb_strlen($field['title'], 'UTF-8');
+				if ($len <= self::TITLE_MAX_LENGTH) {
+					continue;
+				}
+				$q_list['qs'][$index]['title'] = mb_substr($field['title'], 0, self::TITLE_MAX_LENGTH - 1, 'UTF-8') . '…';
+			}
+		}
+		qa_html_theme_base::q_list_and_form($q_list);
+	}
+
+}

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+	Plugin Name: Custom Question List Plugin
+	Plugin URI:
+	Plugin Description: To shorten the title of the list of questions.
+	Plugin Version: 1.0
+	Plugin Date: 2016-07-21
+	Plugin Author: 38qa.net
+	Plugin Author URI: http://38qa.net/
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// page
+// qa_register_plugin_module('page', 'qa-test-page.php', 'qa_test_page', 'Test Page');
+// process
+// qa_register_plugin_module('process', 'qa-test-process.php', 'qa_test_process', 'Test Process');
+// layer
+qa_register_plugin_layer('qa-custom-qlist-layer.php', 'Custom Question List Layer');
+// event
+// qa_register_plugin_module('event', 'qa-test-event.php', 'qa_test_event', 'Test Event');
+// override
+// qa_register_plugin_overrides('qa-test-overrides.php');

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -18,13 +18,5 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 	exit;
 }
 
-// page
-// qa_register_plugin_module('page', 'qa-test-page.php', 'qa_test_page', 'Test Page');
-// process
-// qa_register_plugin_module('process', 'qa-test-process.php', 'qa_test_process', 'Test Process');
 // layer
 qa_register_plugin_layer('qa-custom-qlist-layer.php', 'Custom Question List Layer');
-// event
-// qa_register_plugin_module('event', 'qa-test-event.php', 'qa_test_event', 'Test Event');
-// override
-// qa_register_plugin_overrides('qa-test-overrides.php');


### PR DESCRIPTION
- 質問リストのタイトルを60文字に制限
- 60文字より長い場合は省略して ’...’ 追加
- 質問個別ページのタイトルは長くても省略しない
